### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/DualColourLED/keywords.txt
+++ b/DualColourLED/keywords.txt
@@ -6,15 +6,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DualColourLED KEYWORD1
+DualColourLED	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-drive KEYWORD2
-setColour KEYWORD2
-getColour KEYWORD2
+drive	KEYWORD2
+setColour	KEYWORD2
+getColour	KEYWORD2
 
 
 #######################################
@@ -24,4 +24,4 @@ getColour KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-DualColourLED_H LITERAL1
+DualColourLED_H	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords